### PR TITLE
feat(issue-os): add runtime inspection and operator diagnostics

### DIFF
--- a/docs/cli/runtime-and-sync-commands.md
+++ b/docs/cli/runtime-and-sync-commands.md
@@ -2,6 +2,25 @@
 
 This reference covers the commands that install runtime artifacts, synchronize project state, regenerate contributor instructions, and manage local-only reference repositories.
 
+## Inspect GitHub Runtime State
+
+Use `issue-driven-os github inspect` when you need operator diagnostics for one GitHub-backed runtime root without opening `state.json`, `leases/*.json`, `runs/*.json`, or `artifacts/<runId>/` by hand:
+
+```bash
+npx my-agents issue-driven-os github inspect owner/repo
+npx my-agents issue-driven-os github inspect owner/repo --runtime-root ~/.my-agents/issue-driven-os/owner__repo
+npx my-agents issue-driven-os github inspect owner/repo --runtime-root ~/.my-agents/issue-driven-os/owner__repo --json
+npx my-agents issue-driven-os github inspect owner/repo --runtime-root ~/.my-agents/issue-driven-os/owner__repo --run run_issue_123_20260329T151315Z
+```
+
+The command:
+
+- scopes inspection to one `<owner>/<repo>`
+- shows active leases, issue summary state, and recent runs in deterministic order
+- supports `--run <id>` to show one persisted run record plus concrete artifact file locations
+- supports `--json` for machine-readable diagnostics
+- honors `--runtime-root` the same way the existing GitHub runtime commands do
+
 ## Add External Official Assets
 
 Use `add` when you want to append one trusted GitHub-hosted external asset to a project manifest without hand-writing the structured locator fields:

--- a/docs/examples/issue-driven-os/README.md
+++ b/docs/examples/issue-driven-os/README.md
@@ -77,6 +77,7 @@ Available commands:
 - `project`
 - `pipeline`
 - `github produce`
+- `github inspect`
 - `github run`
 - `github daemon`
 - `github reconcile`
@@ -103,6 +104,8 @@ branches, and real pull requests:
 
 - `github produce`
   - turn raw input into a GitHub issue and mark it ready
+- `github inspect`
+  - inspect repo-scoped runtime leases, issue summary state, recent runs, and run artifacts
 - `github run`
   - consume one real issue end to end
 - `github daemon`
@@ -110,14 +113,24 @@ branches, and real pull requests:
 - `github reconcile`
   - sync issue state after merge or projection drift
 
-Example:
+Examples:
 
 ```bash
+npx my-agents issue-driven-os github inspect owner/repo \
+  --runtime-root ~/.my-agents/issue-driven-os/owner__repo
+
+npx my-agents issue-driven-os github inspect owner/repo \
+  --runtime-root ~/.my-agents/issue-driven-os/owner__repo \
+  --run run_issue_123_20260329T151315Z \
+  --json
+
 npx my-agents issue-driven-os github daemon owner/repo \
   --repo-path /path/to/repo \
   --concurrency 4 \
   --once
 ```
+
+The inspect command supports both human-readable output and `--json`.
 
 This real mode uses:
 

--- a/docs/plans/2026-03-29-github-runtime-inspection-diagnostics.md
+++ b/docs/plans/2026-03-29-github-runtime-inspection-diagnostics.md
@@ -1,0 +1,151 @@
+# GitHub Runtime Inspection Diagnostics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an operator-facing `npx my-agents issue-driven-os github inspect` command that exposes runtime leases, issue summary state, recent runs, and per-run artifact paths in text and JSON forms without changing the persisted runtime layout.
+
+**Architecture:** Extend the existing read side of the issue-driven OS runtime instead of changing the writer path. Add state-store helpers for leases, run records, and artifact files; compose them in a GitHub-runtime inspection module; then surface the result through the existing CLI with deterministic text formatting and JSON output.
+
+**Tech Stack:** Node.js 18+, CommonJS, built-in `node:test`, existing CLI/runtime helpers under `scripts/lib/`
+
+---
+
+### Task 1: Add runtime inspection read helpers
+
+**Files:**
+- Modify: `scripts/lib/issue-driven-os-state-store.js`
+- Test: `scripts/tests/issue-driven-os-state-store.test.js`
+
+**Step 1: Write the failing test**
+
+Add coverage that persists lease, run, and artifact fixtures, then asserts helper functions can list lease records, read a run by id, list runs newest-first input-ready, and enumerate artifact files for one run.
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test scripts/tests/issue-driven-os-state-store.test.js`
+Expected: FAIL because the new read helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add read helpers that:
+- safely enumerate `leases/*.json`
+- safely enumerate `runs/*.json`
+- read one run record by id
+- enumerate artifact files under `artifacts/<runId>/`
+- return deterministic ordering
+
+**Step 4: Run test to verify it passes**
+
+Run: `node --test scripts/tests/issue-driven-os-state-store.test.js`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/lib/issue-driven-os-state-store.js scripts/tests/issue-driven-os-state-store.test.js
+git commit -m "feat(issue-os): add runtime inspection read helpers"
+```
+
+### Task 2: Add GitHub runtime inspection summary and formatting
+
+**Files:**
+- Create: `scripts/lib/issue-driven-os-github-inspection.js`
+- Test: `scripts/tests/issue-driven-os-github-inspection.test.js`
+
+**Step 1: Write the failing test**
+
+Add coverage for:
+- empty runtime output
+- populated runtime summary with leases, issue summary state, and recent runs
+- narrowed run inspection with persisted run record and artifact file locations
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test scripts/tests/issue-driven-os-github-inspection.test.js`
+Expected: FAIL because the inspection module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create an inspection module that:
+- builds runtime paths from `<owner>/<repo>` and optional `--runtime-root`
+- reads `state.json`, `leases/*.json`, `runs/*.json`, and `artifacts/<runId>/*`
+- returns stable JSON-friendly payloads
+- formats human-readable diagnostics for summary mode and run-detail mode
+
+**Step 4: Run test to verify it passes**
+
+Run: `node --test scripts/tests/issue-driven-os-github-inspection.test.js`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/lib/issue-driven-os-github-inspection.js scripts/tests/issue-driven-os-github-inspection.test.js
+git commit -m "feat(issue-os): add runtime inspection formatter"
+```
+
+### Task 3: Surface the command in the CLI
+
+**Files:**
+- Modify: `scripts/issue-driven-os-cli.js`
+- Modify: `scripts/tests/cli.test.js`
+- Modify: `docs/examples/issue-driven-os/README.md`
+
+**Step 1: Write the failing test**
+
+Add CLI help and command-behavior coverage for:
+- `github inspect` appearing in usage
+- missing `<owner>/<repo>` failing clearly
+- `--json` emitting the inspection payload
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test scripts/tests/cli.test.js scripts/tests/issue-driven-os-github-inspection.test.js`
+Expected: FAIL because the CLI does not route the new command yet.
+
+**Step 3: Write minimal implementation**
+
+Wire `github inspect` into `scripts/issue-driven-os-cli.js`, reuse the existing `--runtime-root` behavior, support optional `--run <id>` and `--limit <n>`, and document the new command in CLI-facing docs.
+
+**Step 4: Run test to verify it passes**
+
+Run: `node --test scripts/tests/cli.test.js scripts/tests/issue-driven-os-github-inspection.test.js`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/issue-driven-os-cli.js scripts/tests/cli.test.js docs/examples/issue-driven-os/README.md
+git commit -m "feat(issue-os): add github runtime inspect command"
+```
+
+### Task 4: Final verification
+
+**Files:**
+- Modify: `docs/cli/runtime-and-sync-commands.md`
+
+**Step 1: Run full targeted verification**
+
+Run: `node --test scripts/tests/cli.test.js scripts/tests/issue-driven-os-state-store.test.js scripts/tests/issue-driven-os-github-inspection.test.js`
+Expected: PASS
+
+**Step 2: Run repo validation slices that could catch integration drift**
+
+Run: `npm run test:node`
+Expected: PASS
+
+**Step 3: Update docs if needed**
+
+Document the operator diagnostics command in the CLI docs if the help output is now the only missing discoverability surface.
+
+**Step 4: Re-run verification**
+
+Run: `npm run test:node`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add docs/cli/runtime-and-sync-commands.md
+git commit -m "docs(issue-os): document runtime inspection diagnostics"
+```

--- a/scripts/issue-driven-os-cli.js
+++ b/scripts/issue-driven-os-cli.js
@@ -15,6 +15,10 @@ const {
 const { runReferenceScenario } = require("./lib/issue-driven-os-run-manager");
 const { projectReferenceRuntimeSession } = require("./lib/issue-driven-os-projection-adapter");
 const {
+  formatGitHubRuntimeInspection,
+  inspectGitHubRuntime
+} = require("./lib/issue-driven-os-github-inspection");
+const {
   produceGitHubIssue,
   reconcileIssue,
   runGitHubDaemon,
@@ -28,6 +32,7 @@ const ISSUE_DRIVEN_OS_USAGE = `Usage:
   npx my-agents issue-driven-os project <session-path> [--out <path>] [--json]
   npx my-agents issue-driven-os pipeline <scenario-id> [--out-dir <path>] [--json]
   npx my-agents issue-driven-os github produce <owner>/<repo> --repo-path <path> --from <path|->
+  npx my-agents issue-driven-os github inspect <owner>/<repo> [--runtime-root <path>] [--run <id>] [--limit <n>] [--json]
   npx my-agents issue-driven-os github run <owner>/<repo> --repo-path <path> --issue <number> [--json]
   npx my-agents issue-driven-os github daemon <owner>/<repo> --repo-path <path> [--concurrency <n>] [--poll-seconds <n>] [--once] [--json]
   npx my-agents issue-driven-os github reconcile <owner>/<repo> --issue <number> [--branch <name>] [--json]
@@ -39,6 +44,7 @@ Examples:
   npx my-agents issue-driven-os project .tmp/f1-session.json
   npx my-agents issue-driven-os pipeline G1
   npx my-agents issue-driven-os pipeline GT1 --out-dir .tmp/gt1-pipeline
+  npx my-agents issue-driven-os github inspect owner/repo --run run_issue_123_20260329T151315Z
   npx my-agents issue-driven-os github run owner/repo --repo-path /path/to/repo --issue 123
   npx my-agents issue-driven-os github daemon owner/repo --repo-path /path/to/repo --concurrency 4 --once`;
 
@@ -225,6 +231,33 @@ async function runGitHubProduce(repoRoot, args) {
   );
 }
 
+async function runGitHubInspect(_repoRoot, args) {
+  const asJson = args.includes("--json");
+  const runtimeRoot = parseValueFlag(args, "--runtime-root");
+  const runId = parseValueFlag(args, "--run");
+  const repoSlug = firstPositionalArg(
+    args,
+    excludedFlagValues(args, ["--runtime-root", "--run", "--limit"])
+  );
+  if (!repoSlug) throw new Error("Missing owner/repo.");
+  if (args.includes("--run") && !runId) {
+    throw new Error("Missing --run value.");
+  }
+
+  const result = await inspectGitHubRuntime(repoSlug, {
+    runtimeRoot: runtimeRoot ? path.resolve(process.cwd(), runtimeRoot) : undefined,
+    runId,
+    limit: parseIntegerFlag(args, "--limit", 10)
+  });
+
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  process.stdout.write(formatGitHubRuntimeInspection(result));
+}
+
 async function runGitHubSingleIssue(repoRoot, args) {
   const asJson = args.includes("--json");
   const issueNumber = parseIntegerFlag(args, "--issue");
@@ -339,6 +372,11 @@ async function runGitHub(repoRoot, args) {
 
   if (subcommand === "produce") {
     await runGitHubProduce(repoRoot, rest);
+    return;
+  }
+
+  if (subcommand === "inspect") {
+    await runGitHubInspect(repoRoot, rest);
     return;
   }
 

--- a/scripts/lib/issue-driven-os-github-inspection.js
+++ b/scripts/lib/issue-driven-os-github-inspection.js
@@ -1,0 +1,257 @@
+const path = require("node:path");
+
+const {
+  buildRuntimePaths,
+  compareIssueNumbers,
+  listIssueLeases,
+  listRunArtifactFiles,
+  listRunRecords,
+  readRunRecord,
+  readRuntimeState
+} = require("./issue-driven-os-state-store");
+
+function compareIssueSummaryRecords(left, right) {
+  const issueCompare = compareIssueNumbers(left.issueNumber, right.issueNumber);
+  if (issueCompare !== 0) {
+    return issueCompare;
+  }
+
+  return String(left.latestRunId ?? "").localeCompare(String(right.latestRunId ?? ""));
+}
+
+function normalizeIssueSummary(issueSummary = {}) {
+  return {
+    issueNumber: issueSummary.issueNumber ?? null,
+    latestRunId: issueSummary.latestRunId ?? null,
+    status: issueSummary.status ?? null,
+    updatedAt: issueSummary.updatedAt ?? null,
+    branchRef: issueSummary.branchRef ?? null,
+    prNumber: issueSummary.prNumber ?? null
+  };
+}
+
+function normalizeLease(lease = {}) {
+  return {
+    issueNumber: lease.issueNumber ?? null,
+    holderId: lease.holderId ?? null,
+    holderType: lease.holderType ?? null,
+    runId: lease.runId ?? null,
+    createdAt: lease.createdAt ?? null,
+    expiresAt: lease.expiresAt ?? null,
+    leasePath: lease.leasePath ?? null
+  };
+}
+
+function normalizeRunSummary(runRecord = {}) {
+  return {
+    id: runRecord.id ?? null,
+    issueNumber: runRecord.issueNumber ?? null,
+    status: runRecord.status ?? null,
+    startedAt: runRecord.startedAt ?? null,
+    updatedAt: runRecord.updatedAt ?? null,
+    finishedAt: runRecord.finishedAt ?? null,
+    branchRef: runRecord.branchRef ?? null,
+    prNumber: runRecord.prNumber ?? null,
+    prUrl: runRecord.prUrl ?? null,
+    summary: runRecord.summary ?? null,
+    runPath: runRecord.runPath ?? null
+  };
+}
+
+function normalizeArtifactFile(file = {}) {
+  return {
+    kind: file.kind ?? null,
+    name: file.name ?? null,
+    path: file.path ?? null,
+    sizeBytes: file.sizeBytes ?? null,
+    updatedAt: file.updatedAt ?? null
+  };
+}
+
+function renderListSection(lines, title, entries, emptyLine) {
+  lines.push("", title);
+
+  if (entries.length === 0) {
+    lines.push(`- ${emptyLine}`);
+    return;
+  }
+
+  lines.push(...entries);
+}
+
+function formatLeaseLine(lease) {
+  return [
+    `- issue #${lease.issueNumber}`,
+    `holder ${lease.holderId ?? "n/a"} (${lease.holderType ?? "unknown"})`,
+    lease.runId ? `run ${lease.runId}` : null,
+    `expires ${lease.expiresAt ?? "n/a"}`
+  ]
+    .filter(Boolean)
+    .join(" | ");
+}
+
+function formatIssueSummaryLine(issueSummary) {
+  return [
+    `- issue #${issueSummary.issueNumber}`,
+    issueSummary.status ?? "unknown",
+    issueSummary.latestRunId ? `latest run ${issueSummary.latestRunId}` : null,
+    issueSummary.updatedAt ? `updated ${issueSummary.updatedAt}` : null,
+    issueSummary.branchRef ? `branch ${issueSummary.branchRef}` : null,
+    issueSummary.prNumber ? `PR #${issueSummary.prNumber}` : null
+  ]
+    .filter(Boolean)
+    .join(" | ");
+}
+
+function formatRunSummaryLine(runRecord) {
+  return [
+    `- ${runRecord.id}`,
+    `issue #${runRecord.issueNumber}`,
+    runRecord.status ?? "unknown",
+    runRecord.updatedAt ? `updated ${runRecord.updatedAt}` : null,
+    runRecord.branchRef ? `branch ${runRecord.branchRef}` : null,
+    runRecord.prNumber ? `PR #${runRecord.prNumber}` : null,
+    !runRecord.prNumber && runRecord.prUrl ? `PR ${runRecord.prUrl}` : null
+  ]
+    .filter(Boolean)
+    .join(" | ");
+}
+
+async function inspectGitHubRuntime(repoSlug, options = {}) {
+  const runtimePaths = buildRuntimePaths(repoSlug, {
+    runtimeRoot: options.runtimeRoot
+  });
+  const state = await readRuntimeState(runtimePaths, repoSlug);
+  const activeLeases = (await listIssueLeases(runtimePaths)).map(normalizeLease);
+
+  if (options.runId) {
+    const runRecord = await readRunRecord(runtimePaths, options.runId);
+    if (!runRecord) {
+      throw new Error(`Run record not found: ${options.runId}`);
+    }
+
+    const artifactFiles = (await listRunArtifactFiles(runtimePaths, options.runId)).map(
+      normalizeArtifactFile
+    );
+
+    return {
+      mode: "run",
+      repoSlug,
+      runtimeRoot: runtimePaths.baseDir,
+      stateFilePath: runtimePaths.stateFilePath,
+      runId: options.runId,
+      run: runRecord,
+      issueSummary: normalizeIssueSummary(state.issues[String(runRecord.issueNumber)]),
+      activeLease:
+        activeLeases.find((lease) => Number(lease.issueNumber) === Number(runRecord.issueNumber)) ??
+        null,
+      artifacts: {
+        directory: path.join(runtimePaths.artifactsDir, options.runId),
+        files: artifactFiles,
+        references: Array.isArray(runRecord.artifacts) ? runRecord.artifacts : []
+      }
+    };
+  }
+
+  const issueSummaries = Object.values(state.issues ?? {})
+    .map(normalizeIssueSummary)
+    .sort(compareIssueSummaryRecords);
+  const allRuns = await listRunRecords(runtimePaths);
+  const recentRunLimit = Math.max(1, Number(options.limit ?? 10));
+  const recentRuns = allRuns.slice(0, recentRunLimit).map(normalizeRunSummary);
+
+  return {
+    mode: "summary",
+    repoSlug,
+    runtimeRoot: runtimePaths.baseDir,
+    stateFilePath: runtimePaths.stateFilePath,
+    recentRunLimit,
+    activeLeases,
+    issueSummaries,
+    recentRuns,
+    activeLeaseCount: activeLeases.length,
+    trackedIssueCount: issueSummaries.length,
+    totalRunCount: allRuns.length
+  };
+}
+
+function formatGitHubRuntimeInspection(report) {
+  const lines = [
+    `Repo: ${report.repoSlug}`,
+    `Runtime root: ${report.runtimeRoot}`,
+    `State file: ${report.stateFilePath}`
+  ];
+
+  if (report.mode === "run") {
+    const runRecord = report.run;
+    lines.push(
+      "",
+      "Run detail",
+      `Run id: ${runRecord.id}`,
+      `Run record: ${runRecord.runPath}`,
+      `Issue: #${runRecord.issueNumber}`,
+      `Status: ${runRecord.status ?? "unknown"}`,
+      `Updated: ${runRecord.updatedAt ?? "n/a"}`,
+      `Started: ${runRecord.startedAt ?? "n/a"}`,
+      `Finished: ${runRecord.finishedAt ?? "n/a"}`,
+      `Branch: ${runRecord.branchRef ?? "n/a"}`,
+      `PR: ${
+        runRecord.prNumber ? `#${runRecord.prNumber}` : runRecord.prUrl ? runRecord.prUrl : "n/a"
+      }`,
+      `Summary: ${runRecord.summary ?? "n/a"}`,
+      `Artifacts dir: ${report.artifacts.directory}`
+    );
+
+    renderListSection(
+      lines,
+      "Artifact files",
+      report.artifacts.files.map((file) => `- ${file.kind}: ${file.path}`),
+      "none"
+    );
+    renderListSection(
+      lines,
+      "Persisted artifact refs",
+      (report.artifacts.references ?? []).map(
+        (artifact) => `- ${artifact.kind ?? "unknown"}: ${artifact.path ?? "n/a"}`
+      ),
+      "none"
+    );
+
+    if (report.issueSummary?.latestRunId) {
+      renderListSection(
+        lines,
+        "Issue summary state",
+        [formatIssueSummaryLine(report.issueSummary)],
+        "none"
+      );
+    }
+
+    if (report.activeLease) {
+      renderListSection(lines, "Active lease", [formatLeaseLine(report.activeLease)], "none");
+    }
+
+    return `${lines.join("\n")}\n`;
+  }
+
+  lines.push(
+    `Active leases: ${report.activeLeaseCount}`,
+    `Tracked issues: ${report.trackedIssueCount}`,
+    `Recent runs shown: ${report.recentRuns.length}/${report.totalRunCount}`
+  );
+
+  renderListSection(lines, "Active leases", report.activeLeases.map(formatLeaseLine), "none");
+  renderListSection(
+    lines,
+    "Issue summary state",
+    report.issueSummaries.map(formatIssueSummaryLine),
+    "none"
+  );
+  renderListSection(lines, "Recent runs", report.recentRuns.map(formatRunSummaryLine), "none");
+
+  return `${lines.join("\n")}\n`;
+}
+
+module.exports = {
+  formatGitHubRuntimeInspection,
+  inspectGitHubRuntime
+};

--- a/scripts/lib/issue-driven-os-state-store.js
+++ b/scripts/lib/issue-driven-os-state-store.js
@@ -13,6 +13,53 @@ function sanitizeRepoSlug(repoSlug) {
     .replace(/[^A-Za-z0-9._-]/g, "_");
 }
 
+function compareStrings(left, right) {
+  return String(left ?? "").localeCompare(String(right ?? ""));
+}
+
+function toTimestamp(value, fallback) {
+  const timestamp = Date.parse(value ?? "");
+  return Number.isNaN(timestamp) ? fallback : timestamp;
+}
+
+function compareIssueNumbers(left, right) {
+  const leftNumber = Number(left);
+  const rightNumber = Number(right);
+
+  if (!Number.isNaN(leftNumber) && !Number.isNaN(rightNumber) && leftNumber !== rightNumber) {
+    return leftNumber - rightNumber;
+  }
+
+  return compareStrings(left, right);
+}
+
+function compareLeaseRecords(left, right) {
+  const issueCompare = compareIssueNumbers(left.issueNumber, right.issueNumber);
+  if (issueCompare !== 0) {
+    return issueCompare;
+  }
+
+  return compareStrings(left.holderId, right.holderId);
+}
+
+function compareRunRecords(left, right) {
+  const updatedCompare =
+    toTimestamp(right.updatedAt, Number.NEGATIVE_INFINITY) -
+    toTimestamp(left.updatedAt, Number.NEGATIVE_INFINITY);
+  if (updatedCompare !== 0) {
+    return updatedCompare;
+  }
+
+  const startedCompare =
+    toTimestamp(right.startedAt, Number.NEGATIVE_INFINITY) -
+    toTimestamp(left.startedAt, Number.NEGATIVE_INFINITY);
+  if (startedCompare !== 0) {
+    return startedCompare;
+  }
+
+  return compareStrings(right.id, left.id);
+}
+
 function buildRuntimePaths(repoSlug, options = {}) {
   const baseDir =
     options.runtimeRoot ??
@@ -86,6 +133,31 @@ async function writeRuntimeState(runtimePaths, state) {
 
   await writeJsonAtomic(runtimePaths.stateFilePath, normalized);
   return normalized;
+}
+
+async function listJsonFiles(dirPath) {
+  if (!(await fileExists(dirPath))) {
+    return [];
+  }
+
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => path.join(dirPath, entry.name))
+    .sort(compareStrings);
+}
+
+async function readJsonOrNull(jsonPath) {
+  if (!(await fileExists(jsonPath))) {
+    return null;
+  }
+
+  try {
+    const parsed = await readJson(jsonPath);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 function leasePathForIssue(runtimePaths, issueNumber) {
@@ -168,6 +240,36 @@ async function releaseIssueLease(runtimePaths, issueNumber, holderId) {
   return true;
 }
 
+function isLeaseExpired(lease, now = new Date()) {
+  const expiresAt = Date.parse(lease?.expiresAt ?? "");
+  return !Number.isNaN(expiresAt) && expiresAt < now.getTime();
+}
+
+async function listIssueLeases(runtimePaths, options = {}) {
+  const now = options.now ?? new Date();
+  const includeExpired = options.includeExpired ?? false;
+  const leaseFiles = await listJsonFiles(runtimePaths.leasesDir);
+  const leases = [];
+
+  for (const leasePath of leaseFiles) {
+    const lease = await readJsonOrNull(leasePath);
+    if (!lease) {
+      continue;
+    }
+
+    if (!includeExpired && isLeaseExpired(lease, now)) {
+      continue;
+    }
+
+    leases.push({
+      ...lease,
+      leasePath
+    });
+  }
+
+  return leases.sort(compareLeaseRecords);
+}
+
 function buildRunId(issueNumber, options = {}) {
   const timestamp = (options.startedAt ?? new Date().toISOString())
     .replace(/[-:]/g, "")
@@ -202,6 +304,38 @@ async function persistRunRecord(runtimePaths, runRecord) {
   return runPath;
 }
 
+async function readRunRecord(runtimePaths, runId) {
+  const runPath = path.join(runtimePaths.runsDir, `${runId}.json`);
+  const runRecord = await readJsonOrNull(runPath);
+  if (!runRecord) {
+    return null;
+  }
+
+  return {
+    ...runRecord,
+    runPath
+  };
+}
+
+async function listRunRecords(runtimePaths) {
+  const runFiles = await listJsonFiles(runtimePaths.runsDir);
+  const runRecords = [];
+
+  for (const runPath of runFiles) {
+    const runRecord = await readJsonOrNull(runPath);
+    if (!runRecord) {
+      continue;
+    }
+
+    runRecords.push({
+      ...runRecord,
+      runPath
+    });
+  }
+
+  return runRecords.sort(compareRunRecords);
+}
+
 async function recordRunUpdate(runtimePaths, repoSlug, runRecord) {
   const state = await readRuntimeState(runtimePaths, repoSlug);
   state.runs[runRecord.id] = {
@@ -228,17 +362,51 @@ async function persistArtifact(runtimePaths, runId, kind, payload) {
   return artifactPath;
 }
 
+async function listRunArtifactFiles(runtimePaths, runId) {
+  const artifactDir = path.join(runtimePaths.artifactsDir, runId);
+  if (!(await fileExists(artifactDir))) {
+    return [];
+  }
+
+  const entries = await fs.readdir(artifactDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const artifactPath = path.join(artifactDir, entry.name);
+    const stats = await fs.stat(artifactPath);
+    files.push({
+      name: entry.name,
+      kind: path.extname(entry.name) === ".json" ? path.basename(entry.name, ".json") : entry.name,
+      path: artifactPath,
+      sizeBytes: stats.size,
+      updatedAt: stats.mtime.toISOString()
+    });
+  }
+
+  return files.sort((left, right) => compareStrings(left.name, right.name));
+}
+
 module.exports = {
   DEFAULT_LEASE_TTL_MS,
   acquireIssueLease,
   buildRunId,
   buildRunRecord,
   buildRuntimePaths,
+  compareIssueNumbers,
   createEmptyRuntimeState,
   ensureRuntimeLayout,
+  isLeaseExpired,
+  listIssueLeases,
+  listRunArtifactFiles,
+  listRunRecords,
   persistArtifact,
   persistRunRecord,
   readLease,
+  readRunRecord,
   readRuntimeState,
   recordRunUpdate,
   releaseIssueLease,

--- a/scripts/tests/cli.test.js
+++ b/scripts/tests/cli.test.js
@@ -77,6 +77,10 @@ test("issue-driven-os help documents the unified runtime flow surface", () => {
   );
   assert.match(
     output,
+    /npx my-agents issue-driven-os github inspect <owner>\/<repo> \[--runtime-root <path>\] \[--run <id>\] \[--limit <n>\] \[--json\]/
+  );
+  assert.match(
+    output,
     /npx my-agents issue-driven-os github run <owner>\/<repo> --repo-path <path> --issue <number> \[--json\]/
   );
 });

--- a/scripts/tests/issue-driven-os-github-inspection.test.js
+++ b/scripts/tests/issue-driven-os-github-inspection.test.js
@@ -1,0 +1,234 @@
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("node:child_process");
+
+const cliPath = path.join(__dirname, "..", "cli.js");
+const repoRoot = path.join(__dirname, "..", "..");
+const {
+  acquireIssueLease,
+  buildRunRecord,
+  buildRuntimePaths,
+  persistArtifact,
+  persistRunRecord,
+  recordRunUpdate
+} = require("../lib/issue-driven-os-state-store");
+
+function runCli(args) {
+  return execFileSync(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+}
+
+function runCliWithStatus(args) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+}
+
+async function seedRuntimeFixture(tempRoot) {
+  const runtimePaths = buildRuntimePaths("owner/repo", { runtimeRoot: tempRoot });
+  const leaseNow = new Date();
+  const olderRun = buildRunRecord(7, {
+    id: "run_issue_7_20260329T090000Z",
+    repoSlug: "owner/repo",
+    status: "blocked",
+    startedAt: "2026-03-29T09:00:00.000Z",
+    updatedAt: "2026-03-29T09:05:00.000Z",
+    summary: "Waiting on missing repository context."
+  });
+  const newerRun = buildRunRecord(8, {
+    id: "run_issue_8_20260329T100000Z",
+    repoSlug: "owner/repo",
+    status: "awaiting_merge",
+    startedAt: "2026-03-29T10:00:00.000Z",
+    updatedAt: "2026-03-29T10:20:00.000Z",
+    branchRef: "agent/issue-8",
+    prNumber: 88,
+    prUrl: "https://example.test/pull/88",
+    summary: "Pull request opened and auto-merge enabled."
+  });
+
+  await persistRunRecord(runtimePaths, olderRun);
+  await recordRunUpdate(runtimePaths, "owner/repo", olderRun);
+
+  const executionPath = await persistArtifact(runtimePaths, newerRun.id, "execution", {
+    status: "implemented"
+  });
+  const criticPath = await persistArtifact(runtimePaths, newerRun.id, "critic", {
+    verdict: "ready"
+  });
+  newerRun.artifacts = [
+    { kind: "execution", path: executionPath },
+    { kind: "critic", path: criticPath }
+  ];
+  await persistRunRecord(runtimePaths, newerRun);
+  await recordRunUpdate(runtimePaths, "owner/repo", newerRun);
+
+  await acquireIssueLease(
+    runtimePaths,
+    8,
+    {
+      holderId: "daemon-1",
+      holderType: "daemon",
+      runId: newerRun.id
+    },
+    {
+      now: leaseNow,
+      ttlMs: 24 * 60 * 60 * 1000
+    }
+  );
+
+  return {
+    runtimePaths,
+    olderRun,
+    newerRun,
+    executionPath,
+    criticPath
+  };
+}
+
+test("issue-driven-os github inspect requires an owner/repo slug", () => {
+  const result = runCliWithStatus(["issue-driven-os", "github", "inspect"]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Missing owner\/repo/);
+});
+
+test("issue-driven-os github inspect renders an empty runtime summary in text mode", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "issue-os-inspect-empty-"));
+
+  try {
+    const output = runCli([
+      "issue-driven-os",
+      "github",
+      "inspect",
+      "owner/repo",
+      "--runtime-root",
+      tempRoot
+    ]);
+
+    assert.match(output, /Repo: owner\/repo/);
+    assert.match(
+      output,
+      new RegExp(`Runtime root: ${tempRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`)
+    );
+    assert.match(output, /Active leases: 0/);
+    assert.match(output, /Tracked issues: 0/);
+    assert.match(output, /Recent runs shown: 0\/0/);
+    assert.match(output, /Active leases\n- none/);
+    assert.match(output, /Issue summary state\n- none/);
+    assert.match(output, /Recent runs\n- none/);
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("issue-driven-os github inspect returns populated runtime summaries in text and JSON modes", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "issue-os-inspect-populated-"));
+
+  try {
+    const { olderRun, newerRun } = await seedRuntimeFixture(tempRoot);
+
+    const textOutput = runCli([
+      "issue-driven-os",
+      "github",
+      "inspect",
+      "owner/repo",
+      "--runtime-root",
+      tempRoot
+    ]);
+    const jsonOutput = runCli([
+      "issue-driven-os",
+      "github",
+      "inspect",
+      "owner/repo",
+      "--runtime-root",
+      tempRoot,
+      "--json"
+    ]);
+    const payload = JSON.parse(jsonOutput);
+
+    assert.match(textOutput, new RegExp(`run ${newerRun.id}`));
+    assert.match(textOutput, new RegExp(`- ${newerRun.id} \\| issue #8 \\| awaiting_merge`));
+    assert.match(textOutput, new RegExp(`- ${olderRun.id} \\| issue #7 \\| blocked`));
+
+    assert.equal(payload.mode, "summary");
+    assert.equal(payload.repoSlug, "owner/repo");
+    assert.equal(payload.activeLeaseCount, 1);
+    assert.deepEqual(
+      payload.issueSummaries.map((issueSummary) => issueSummary.issueNumber),
+      [7, 8]
+    );
+    assert.deepEqual(
+      payload.recentRuns.map((runRecord) => runRecord.id),
+      [newerRun.id, olderRun.id]
+    );
+    assert.equal(payload.recentRuns[0].branchRef, "agent/issue-8");
+    assert.equal(payload.recentRuns[0].prNumber, 88);
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("issue-driven-os github inspect returns run detail with artifact locations", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "issue-os-inspect-run-"));
+
+  try {
+    const { newerRun, criticPath, executionPath } = await seedRuntimeFixture(tempRoot);
+    const jsonOutput = runCli([
+      "issue-driven-os",
+      "github",
+      "inspect",
+      "owner/repo",
+      "--runtime-root",
+      tempRoot,
+      "--run",
+      newerRun.id,
+      "--json"
+    ]);
+    const textOutput = runCli([
+      "issue-driven-os",
+      "github",
+      "inspect",
+      "owner/repo",
+      "--runtime-root",
+      tempRoot,
+      "--run",
+      newerRun.id
+    ]);
+    const payload = JSON.parse(jsonOutput);
+
+    assert.equal(payload.mode, "run");
+    assert.equal(payload.run.id, newerRun.id);
+    assert.equal(payload.run.runPath.endsWith(`${newerRun.id}.json`), true);
+    assert.deepEqual(
+      payload.artifacts.files.map((file) => file.path),
+      [criticPath, executionPath]
+    );
+    assert.deepEqual(
+      payload.artifacts.references.map((artifact) => artifact.path),
+      [executionPath, criticPath]
+    );
+    assert.equal(payload.issueSummary.latestRunId, newerRun.id);
+    assert.match(textOutput, /Run detail/);
+    assert.match(
+      textOutput,
+      new RegExp(`Artifacts dir: ${tempRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`)
+    );
+    assert.match(
+      textOutput,
+      new RegExp(`critic: ${criticPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`)
+    );
+    assert.match(
+      textOutput,
+      new RegExp(`execution: ${executionPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`)
+    );
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/issue-driven-os-state-store.test.js
+++ b/scripts/tests/issue-driven-os-state-store.test.js
@@ -8,9 +8,13 @@ const {
   acquireIssueLease,
   buildRunRecord,
   buildRuntimePaths,
+  listIssueLeases,
+  listRunArtifactFiles,
+  listRunRecords,
   persistArtifact,
   persistRunRecord,
   readLease,
+  readRunRecord,
   recordRunUpdate,
   releaseIssueLease
 } = require("../lib/issue-driven-os-state-store");
@@ -66,6 +70,65 @@ test("issue-driven-os state store persists runs, artifacts, and summary state", 
     assert.equal(savedArtifact.verdict, "ready");
     assert.equal(savedState.issues["42"].latestRunId, runRecord.id);
     assert.equal(savedState.runs[runRecord.id].status, "awaiting_merge");
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("issue-driven-os state store lists leases, runs, and run artifacts for inspection", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "issue-os-state-inspect-"));
+
+  try {
+    const runtimePaths = buildRuntimePaths("owner/repo", { runtimeRoot: tempRoot });
+    const olderRun = buildRunRecord(11, {
+      id: "run_issue_11_20260329T010000Z",
+      repoSlug: "owner/repo",
+      status: "blocked",
+      startedAt: "2026-03-29T01:00:00.000Z",
+      updatedAt: "2026-03-29T01:05:00.000Z"
+    });
+    const newerRun = buildRunRecord(12, {
+      id: "run_issue_12_20260329T020000Z",
+      repoSlug: "owner/repo",
+      status: "awaiting_merge",
+      startedAt: "2026-03-29T02:00:00.000Z",
+      updatedAt: "2026-03-29T02:10:00.000Z"
+    });
+
+    await persistRunRecord(runtimePaths, olderRun);
+    await persistRunRecord(runtimePaths, newerRun);
+    await persistArtifact(runtimePaths, newerRun.id, "critic", {
+      verdict: "ready"
+    });
+    await acquireIssueLease(
+      runtimePaths,
+      12,
+      {
+        holderId: "daemon-1",
+        holderType: "daemon",
+        runId: newerRun.id
+      },
+      {
+        now: new Date("2026-03-29T02:00:00.000Z"),
+        ttlMs: 5 * 60 * 1000
+      }
+    );
+
+    const leases = await listIssueLeases(runtimePaths, {
+      now: new Date("2026-03-29T02:01:00.000Z")
+    });
+    const runs = await listRunRecords(runtimePaths);
+    const savedRun = await readRunRecord(runtimePaths, newerRun.id);
+    const artifactFiles = await listRunArtifactFiles(runtimePaths, newerRun.id);
+
+    assert.equal(leases.length, 1);
+    assert.equal(leases[0].holderType, "daemon");
+    assert.equal(runs.map((run) => run.id).join(","), `${newerRun.id},${olderRun.id}`);
+    assert.equal(savedRun.runPath.endsWith(`${newerRun.id}.json`), true);
+    assert.deepEqual(
+      artifactFiles.map((file) => file.kind),
+      ["critic"]
+    );
   } finally {
     await fs.rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add a repo-scoped `github inspect` CLI for the issue-driven GitHub runtime
- surface active leases, issue summary state, recent runs, and run artifact paths in text and JSON forms
- keep the implementation read-only against the existing runtime store layout

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run test:node`

Execution Summary: agents=none; skills=writing-plans, verification-before-completion; tools=exec_command, apply_patch, update_plan, multi_tool_use.parallel; verification=`npm run format:check`, `npm run lint`, `npm run test:node`
Closes #4
## Agent Summary
Added `npx my-agents issue-driven-os github inspect <owner>/<repo>` with `--runtime-root`, `--run`, `--limit`, and `--json` support in `scripts/issue-driven-os-cli.js`. Added read-side runtime helpers in `scripts/lib/issue-driven-os-state-store.js` and a new inspection/formatting module in `scripts/lib/issue-driven-os-github-inspection.js` to summarize `state.json`, `leases/*.json`, `runs/*.json`, and `artifacts/<runId>/*` without changing the store format. Added coverage in `scripts/tests/issue-driven-os-github-inspection.test.js`, expanded CLI/state-store tests, and documented the new operator flow in `docs/examples/issue-driven-os/README.md` and `docs/cli/runtime-and-sync-commands.md`.
## Verification
Verified with fresh runs of `npm run format:check`, `npm run lint`, and `npm run test:node`; all passed. I also ran focused diagnostics coverage during development with `node --test scripts/tests/issue-driven-os-state-store.test.js` and `node --test scripts/tests/cli.test.js scripts/tests/issue-driven-os-github-inspection.test.js`. Local verification required `npm install` first because this worktree initially had no `node_modules`.