### PR TITLE
fix(issue-os): make GitHub label bootstrap idempotent

### DIFF
--- a/scripts/lib/issue-driven-os-github-adapter.js
+++ b/scripts/lib/issue-driven-os-github-adapter.js
@@ -156,12 +156,34 @@ function buildGhAdapter(options = {}) {
     });
   }
 
+  async function labelExists(repoSlug, labelName, options = {}) {
+    const { owner, repo } = parseRepoSlug(repoSlug);
+
+    try {
+      await readJson(
+        ["api", `repos/${owner}/${repo}/labels/${encodeURIComponent(labelName)}`],
+        options.commandOptions
+      );
+      return true;
+    } catch (error) {
+      if (/404/i.test(error.message)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
   async function ensureLabels(repoSlug, labels = DEFAULT_AGENT_LABELS, options = {}) {
     const { owner, repo } = parseRepoSlug(repoSlug);
 
+    // Bootstrap label presence idempotently and leave existing metadata untouched.
     for (const label of labels) {
+      if (await labelExists(repoSlug, label.name, options)) {
+        continue;
+      }
+
       try {
-        await run(
+        await capture(
           "gh",
           [
             "api",
@@ -178,6 +200,7 @@ function buildGhAdapter(options = {}) {
           options.commandOptions
         );
       } catch (error) {
+        // A concurrent bootstrap can win the race between our existence check and create call.
         if (!/already_exists|already exists|422/i.test(error.message)) {
           throw error;
         }

--- a/scripts/tests/issue-driven-os-github-adapter.test.js
+++ b/scripts/tests/issue-driven-os-github-adapter.test.js
@@ -1,0 +1,88 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { DEFAULT_AGENT_LABELS, buildGhAdapter } = require("../lib/issue-driven-os-github-adapter");
+
+function findFieldValue(args, fieldName) {
+  const entry = args.find(
+    (value) => value === `name=${fieldName}` || value.startsWith(`${fieldName}=`)
+  );
+  return entry ? entry.slice(fieldName.length + 1) : null;
+}
+
+test("ensureLabels skips labels that already exist", async () => {
+  const existingLabels = new Set(["agent:ready", "agent:blocked"]);
+  const createdLabels = [];
+  const inspectedLabels = [];
+  const github = buildGhAdapter({
+    capture: async (_command, args) => {
+      const pathArg = args.find((value) => value.startsWith("repos/"));
+
+      if (!pathArg) {
+        throw new Error(`unexpected gh call: ${args.join(" ")}`);
+      }
+
+      if (args.includes("--method") && args.includes("POST")) {
+        const labelName = findFieldValue(args, "name");
+        createdLabels.push(labelName);
+        return { stdout: JSON.stringify({ name: labelName }) };
+      }
+
+      const labelName = decodeURIComponent(pathArg.split("/").pop());
+      inspectedLabels.push(labelName);
+
+      if (existingLabels.has(labelName)) {
+        return { stdout: JSON.stringify({ name: labelName }) };
+      }
+
+      throw new Error(`gh ${args.join(" ")} exited with code 1: gh: Not Found (HTTP 404)`);
+    }
+  });
+
+  await github.ensureLabels("owner/repo");
+
+  assert.deepEqual(
+    inspectedLabels,
+    DEFAULT_AGENT_LABELS.map((label) => label.name)
+  );
+  assert.deepEqual(
+    createdLabels,
+    DEFAULT_AGENT_LABELS.map((label) => label.name).filter(
+      (labelName) => !existingLabels.has(labelName)
+    )
+  );
+});
+
+test("ensureLabels treats already-existing create races as idempotent success", async () => {
+  const createdLabels = [];
+  const github = buildGhAdapter({
+    capture: async (_command, args) => {
+      const pathArg = args.find((value) => value.startsWith("repos/"));
+
+      if (!pathArg) {
+        throw new Error(`unexpected gh call: ${args.join(" ")}`);
+      }
+
+      if (!(args.includes("--method") && args.includes("POST"))) {
+        throw new Error(`gh ${args.join(" ")} exited with code 1: gh: Not Found (HTTP 404)`);
+      }
+
+      const labelName = findFieldValue(args, "name");
+      createdLabels.push(labelName);
+
+      if (labelName === "agent:ready") {
+        throw new Error(
+          `${_command} ${args.join(" ")} exited with code 1: gh: Validation Failed (HTTP 422)\n{"errors":[{"resource":"Label","code":"already_exists","field":"name"}]}`
+        );
+      }
+
+      return { stdout: JSON.stringify({ name: labelName }) };
+    }
+  });
+
+  await assert.doesNotReject(() => github.ensureLabels("owner/repo"));
+  assert.deepEqual(
+    createdLabels,
+    DEFAULT_AGENT_LABELS.map((label) => label.name)
+  );
+});

--- a/scripts/tests/issue-driven-os-github-runtime.test.js
+++ b/scripts/tests/issue-driven-os-github-runtime.test.js
@@ -6,6 +6,7 @@ const assert = require("node:assert/strict");
 
 const {
   produceGitHubIssue,
+  runGitHubDaemon,
   runGitHubIssueWorker
 } = require("../lib/issue-driven-os-github-runtime");
 const { buildRuntimePaths } = require("../lib/issue-driven-os-state-store");
@@ -13,9 +14,11 @@ const { buildRuntimePaths } = require("../lib/issue-driven-os-state-store");
 test("produceGitHubIssue normalizes raw input and creates a ready issue", async () => {
   const calls = [];
   const github = {
-    ensureLabels: async () => {},
+    ensureLabels: async () => {
+      calls.push("ensureLabels");
+    },
     createIssue: async (_repoSlug, draft) => {
-      calls.push(draft);
+      calls.push({ type: "createIssue", draft });
       return { number: 101, url: "https://example.test/issues/101" };
     }
   };
@@ -39,7 +42,11 @@ test("produceGitHubIssue normalizes raw input and creates a ready issue", async 
   );
 
   assert.equal(result.issueNumber, 101);
-  assert.deepEqual(calls[0].labels, ["bug", "agent:ready"]);
+  assert.deepEqual(
+    calls.map((entry) => (typeof entry === "string" ? entry : entry.type)),
+    ["ensureLabels", "createIssue"]
+  );
+  assert.deepEqual(calls[1].draft.labels, ["bug", "agent:ready"]);
 });
 
 test("runGitHubIssueWorker executes, critiques, and records a successful issue run", async () => {
@@ -47,19 +54,25 @@ test("runGitHubIssueWorker executes, critiques, and records a successful issue r
   const comments = [];
   const issueEdits = [];
   const prComments = [];
+  const callOrder = [];
   let findPrCalls = 0;
 
   const github = {
-    ensureLabels: async () => {},
-    viewIssue: async () => ({
-      number: 12,
-      title: "Fix the parser",
-      body: "Parser fails on blank lines.",
-      labels: ["agent:ready"],
-      comments: [],
-      state: "OPEN",
-      url: "https://example.test/issues/12"
-    }),
+    ensureLabels: async () => {
+      callOrder.push("ensureLabels");
+    },
+    viewIssue: async () => {
+      callOrder.push("viewIssue");
+      return {
+        number: 12,
+        title: "Fix the parser",
+        body: "Parser fails on blank lines.",
+        labels: ["agent:ready"],
+        comments: [],
+        state: "OPEN",
+        url: "https://example.test/issues/12"
+      };
+    },
     editIssue: async (_repoSlug, _issueNumber, edit) => {
       issueEdits.push(edit);
     },
@@ -161,8 +174,35 @@ test("runGitHubIssueWorker executes, critiques, and records a successful issue r
     assert.equal(issueEdits.length >= 2, true);
     assert.equal(prComments.length, 1);
     assert.equal(runFiles.length, 1);
+    assert.deepEqual(callOrder.slice(0, 2), ["ensureLabels", "viewIssue"]);
     assert.match(comments[0], /claimed this issue/);
   } finally {
     await fs.rm(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("runGitHubDaemon bootstraps labels before scanning issues", async () => {
+  const callOrder = [];
+  const result = await runGitHubDaemon(
+    path.resolve(__dirname, "..", ".."),
+    "owner/repo",
+    process.cwd(),
+    {
+      once: true,
+      github: {
+        ensureLabels: async () => {
+          callOrder.push("ensureLabels");
+        },
+        listIssues: async () => {
+          callOrder.push("listIssues");
+          return [];
+        }
+      }
+    }
+  );
+
+  assert.deepEqual(callOrder, ["ensureLabels", "listIssues"]);
+  assert.equal(result.checked, 0);
+  assert.equal(result.consumed, 0);
+  assert.deepEqual(result.results, []);
 });


### PR DESCRIPTION
## Summary
- make `ensureLabels()` skip `agent:*` labels that already exist
- keep label bootstrap idempotent when GitHub returns create-time `already_exists` / HTTP 422 races
- add regression coverage for adapter behavior and runtime bootstrap entrypoints

## Testing
- npm test

Closes #5
Closes #5
## Agent Summary
Updated `scripts/lib/issue-driven-os-github-adapter.js` so `ensureLabels()` checks each required `agent:*` label before creating it, uses the capturing GitHub command path for create attempts, and treats concurrent `already_exists` / HTTP 422 label-create races as successful bootstrap while leaving existing label metadata untouched. Added `scripts/tests/issue-driven-os-github-adapter.test.js` to cover both pre-existing labels and create-time race responses, and extended `scripts/tests/issue-driven-os-github-runtime.test.js` so produce, worker, and daemon entrypoints keep exercising the shared bootstrap helper.
## Verification
Passed `npm test` (`npm run validate`): lint clean, Prettier check clean, generated instructions up to date, repo validation OK, `node --test scripts/tests/*.test.js` with 51/51 passing, `skills/skill-lifecycle-manager` Python tests with 21/21 passing, and `skills/agent-lifecycle-manager` Python tests with 17/17 passing. Execution Summary: agents=none; skills=systematic-debugging, verification-before-completion; tools=exec_command, apply_patch, update_plan, multi_tool_use.parallel; verification=npm test

---
Agent type: issue-cell-executor
Phase: review
Run id: run_issue_5_20260330T021849Z
Issue: #5
Workflow: issue-driven-os
<!-- issue-driven-os-meta {"schemaVersion":1,"workflow":"issue-driven-os","actor":"issue-cell-executor","phase":"review","channel":"pull_request_body","runId":"run_issue_5_20260330T021849Z","issueNumber":5,"pullRequestNumber":null} -->