### PR TITLE
perf(issue-os): avoid full run scans for inspection summaries

### DIFF
--- a/scripts/lib/issue-driven-os-state-store.js
+++ b/scripts/lib/issue-driven-os-state-store.js
@@ -586,6 +586,20 @@ async function readRunRecord(runtimePaths, runId, options = {}) {
 async function listRunRecords(runtimePaths, options = {}) {
   const warnings = options.warnings ?? [];
   const limit = Math.max(1, Number(options.limit ?? 10));
+  const stateRuns =
+    options.state?.runs && typeof options.state.runs === "object" ? options.state.runs : null;
+
+  if (stateRuns && Object.keys(stateRuns).length > 0) {
+    return Object.entries(stateRuns)
+      .map(([runId, runSummary]) => ({
+        ...runSummary,
+        id: runId,
+        runPath: path.join(runtimePaths.runsDir, `${runId}.json`)
+      }))
+      .sort(compareRunRecords)
+      .slice(0, limit);
+  }
+
   const runFiles = await listJsonFiles(runtimePaths.runsDir);
   const runRecords = [];
 
@@ -613,9 +627,13 @@ async function recordRunUpdate(runtimePaths, repoSlug, runRecord) {
     ...existingRunSummary,
     issueNumber: runRecord.issueNumber,
     status: runRecord.status,
+    startedAt: runRecord.startedAt ?? existingRunSummary.startedAt ?? null,
     updatedAt: runRecord.updatedAt ?? new Date().toISOString(),
+    finishedAt: runRecord.finishedAt ?? existingRunSummary.finishedAt ?? null,
     branchRef: runRecord.branchRef ?? null,
     prNumber: runRecord.prNumber ?? null,
+    prUrl: runRecord.prUrl ?? existingRunSummary.prUrl ?? null,
+    summary: runRecord.summary ?? existingRunSummary.summary ?? null,
     lease: runRecord.lease ?? existingRunSummary.lease ?? null,
     leaseFailure: runRecord.leaseFailure ?? existingRunSummary.leaseFailure ?? null,
     reviewLoopCount: runRecord.reviewLoopCount ?? existingRunSummary.reviewLoopCount ?? 0,
@@ -953,6 +971,7 @@ async function inspectRuntimeState(runtimePaths, repoSlug, options = {}) {
   const activeLeases = allLeases.filter((lease) => lease?.leaseStatus !== "expired");
   const staleLeases = allLeases.filter((lease) => lease?.leaseStatus === "expired");
   const recentRuns = await listRunRecords(runtimePaths, {
+    state,
     warnings,
     limit: options.limit ?? 10
   });

--- a/scripts/tests/issue-driven-os-state-store.test.js
+++ b/scripts/tests/issue-driven-os-state-store.test.js
@@ -284,6 +284,49 @@ test("issue-driven-os state store exposes inspection snapshots and recent events
   }
 });
 
+test("issue-driven-os state store reuses state summaries for recent runs", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "issue-os-inspect-runs-"));
+
+  try {
+    const runtimePaths = buildRuntimePaths("owner/repo", { runtimeRoot: tempRoot });
+    await fs.mkdir(runtimePaths.runsDir, { recursive: true });
+
+    const runIds = [];
+    for (let index = 0; index < 40; index += 1) {
+      const timestamp = new Date(Date.UTC(2026, 2, 30, 0, 0, index)).toISOString();
+      const runRecord = buildRunRecord(index + 1, {
+        id: `run_issue_${index + 1}`,
+        repoSlug: "owner/repo",
+        status: "claimed",
+        startedAt: timestamp,
+        updatedAt: timestamp,
+        summary: `Run ${index + 1}`
+      });
+      runIds.push(runRecord.id);
+      await recordRunUpdate(runtimePaths, "owner/repo", runRecord);
+      await fs.writeFile(
+        path.join(runtimePaths.runsDir, `${runRecord.id}.json`),
+        '{"broken"',
+        "utf8"
+      );
+    }
+
+    const snapshot = await inspectRuntimeState(runtimePaths, "owner/repo", {
+      limit: 3
+    });
+
+    assert.deepEqual(
+      snapshot.recentRuns.map((run) => run.id),
+      runIds.slice(-3).reverse()
+    );
+    assert.equal(snapshot.recentRuns[0].summary, "Run 40");
+    assert.match(snapshot.recentRuns[0].runPath, /run_issue_40\.json$/);
+    assert.deepEqual(snapshot.warnings, []);
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("issue-driven-os state store tails recent events without parsing older malformed history", async () => {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "issue-os-inspect-tail-"));
 


### PR DESCRIPTION
## Summary
- serve recent run inspection from the persisted runtime state summary instead of scanning `runs/` JSON files
- persist the extra summary fields needed for inspection output directly in state updates
- add a synthetic large-history regression test that proves inspect no longer needs readable run files

Closes #14

## Testing
- npm test
