### PR TITLE
perf(codex-runner): make structured trace capture configurable

### DIFF
--- a/scripts/lib/issue-driven-os-codex-runner.js
+++ b/scripts/lib/issue-driven-os-codex-runner.js
@@ -25,7 +25,8 @@ function runCodexExec(args, options = {}) {
     const traceMode = resolveTraceMode(options);
     const captureRichTrace = traceMode === "rich";
     const startedAt = new Date().toISOString();
-    const child = spawn("codex", args, {
+    const spawnImpl = options.spawnImpl ?? spawn;
+    const child = spawnImpl("codex", args, {
       cwd: options.cwd,
       stdio: ["ignore", "pipe", "pipe"],
       env: process.env
@@ -74,9 +75,7 @@ function runCodexExec(args, options = {}) {
     });
 
     child.stderr.on("data", (chunk) => {
-      if (captureRichTrace) {
-        stderr += chunk.toString("utf8");
-      }
+      stderr += chunk.toString("utf8");
     });
 
     child.on("error", reject);
@@ -384,5 +383,6 @@ module.exports = {
   executeGitHubIssue,
   findCodexSessionPath,
   normalizeIssueInput,
+  runCodexExec,
   shapeGitHubIssue
 };

--- a/scripts/tests/issue-driven-os-codex-runner.test.js
+++ b/scripts/tests/issue-driven-os-codex-runner.test.js
@@ -1,9 +1,11 @@
 const fs = require("node:fs/promises");
+const { EventEmitter } = require("node:events");
 const path = require("node:path");
+const { PassThrough } = require("node:stream");
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { executeGitHubIssue } = require("../lib/issue-driven-os-codex-runner");
+const { executeGitHubIssue, runCodexExec } = require("../lib/issue-driven-os-codex-runner");
 
 function buildAgentDefinition() {
   return {
@@ -100,4 +102,34 @@ test("executeGitHubIssue preserves rich trace data when requested", async () => 
   assert.equal(result.trace.events.length, 2);
   assert.equal(result.trace.eventCount, 2);
   assert.equal(result.trace.threadId, "thread_456");
+});
+
+test("runCodexExec keeps stderr diagnostics in compact mode failures", async () => {
+  const repoRoot = path.resolve(__dirname, "..", "..");
+
+  await assert.rejects(
+    runCodexExec(["exec"], {
+      cwd: repoRoot,
+      spawnImpl: () => {
+        const child = new EventEmitter();
+        child.stdout = new PassThrough();
+        child.stderr = new PassThrough();
+
+        setImmediate(() => {
+          child.stderr.write("structured stderr");
+          child.stderr.end();
+          child.stdout.end();
+          child.emit("close", 1);
+        });
+
+        return child;
+      }
+    }),
+    (error) => {
+      assert.match(error.message, /structured stderr/);
+      assert.equal(error.stderr, "structured stderr");
+      assert.equal(error.stdout, "");
+      return true;
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- add compact vs rich trace modes to the structured Codex runner so default success-path runs keep only lightweight trace metadata
- preserve an explicit rich mode for debugging that retains stdout, parsed events, prompt, and final message content
- add focused tests for both default compact capture and explicit rich capture

Closes #15

## Testing
- npm test
