### PR TITLE
refactor(issue-os): cache resume phase in claim and resume flow

### DIFF
--- a/scripts/lib/issue-driven-os-github-runtime.js
+++ b/scripts/lib/issue-driven-os-github-runtime.js
@@ -584,17 +584,37 @@ function buildIssueStartComment(runRecord) {
     .join("\n");
 }
 
-function buildIssueResumeComment(runRecord, resumeContext) {
-  const resumePhase = inferResumePhase(resumeContext);
+function buildIssueResumeComment(runRecord, resumeContext, resumePhase) {
+  const effectiveResumePhase =
+    typeof resumePhase === "undefined" ? inferResumePhase(resumeContext) : resumePhase;
   return [
     `Agent worker resumed this issue.`,
     `Run id: ${runRecord.id}`,
     resumeContext?.run?.status ? `Previous status: ${resumeContext.run.status}` : null,
-    resumePhase ? `Resume phase: ${resumePhase}` : null,
+    effectiveResumePhase ? `Resume phase: ${effectiveResumePhase}` : null,
     runRecord.branchRef ? `Branch: ${runRecord.branchRef}` : null
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+function buildResumeClaimMetadata(runRecord, resumeContext) {
+  if (!resumeContext) {
+    return null;
+  }
+
+  const resumePhase = inferResumePhase(resumeContext);
+
+  return {
+    resumePhase,
+    eventMessage: `Resuming run ${runRecord.id} from ${resumePhase ?? "claim"}.`,
+    eventData: {
+      previousStatus: resumeContext.run.status,
+      resumePhase
+    },
+    issueComment: buildIssueResumeComment(runRecord, resumeContext, resumePhase),
+    executionSummaryVerification: `resume-from-${resumePhase ?? "claim"}`
+  };
 }
 
 function buildIssueRecoveryComment(runRecord, lease, options = {}) {
@@ -1366,6 +1386,7 @@ async function runGitHubIssueWorker(repoRoot, repoSlug, repoPath, issueNumber, o
         repoSlug,
         status: "claimed"
       });
+  const resumeClaim = buildResumeClaimMetadata(runRecord, resumeContext);
   const reviewLoopsMax = resolveReviewLoopsMax(runRecord, options);
   runRecord.reviewLoopCount = normalizeNonNegativeInteger(runRecord.reviewLoopCount, 0);
   runRecord.reviewLoopsMax = reviewLoopsMax;
@@ -1445,11 +1466,8 @@ async function runGitHubIssueWorker(repoRoot, repoSlug, repoPath, issueNumber, o
         actor: "worker",
         phase: "resume",
         event: "run_resumed",
-        message: `Resuming run ${runRecord.id} from ${inferResumePhase(resumeContext) ?? "claim"}.`,
-        data: {
-          previousStatus: resumeContext.run.status,
-          resumePhase: inferResumePhase(resumeContext)
-        }
+        message: resumeClaim.eventMessage,
+        data: resumeClaim.eventData
       });
     }
     await leaseSupervisor.assertActive("claim");
@@ -1482,17 +1500,13 @@ async function runGitHubIssueWorker(repoRoot, repoSlug, repoPath, issueNumber, o
       deps,
       repoSlug,
       issueNumber,
-      resumeContext
-        ? buildIssueResumeComment(runRecord, resumeContext)
-        : buildIssueStartComment(runRecord),
+      resumeClaim ? resumeClaim.issueComment : buildIssueStartComment(runRecord),
       {
         actor: "worker",
         phase: "claim",
         runId: runRecord.id,
         executionSummary: buildWorkerExecutionSummary({
-          verification: resumeContext
-            ? `resume-from-${inferResumePhase(resumeContext) ?? "claim"}`
-            : "claimed"
+          verification: resumeClaim ? resumeClaim.executionSummaryVerification : "claimed"
         })
       },
       options

--- a/scripts/tests/issue-driven-os-github-runtime.test.js
+++ b/scripts/tests/issue-driven-os-github-runtime.test.js
@@ -1387,7 +1387,12 @@ test("runGitHubIssueWorker resumes a failed run from persisted execution state",
     assert.equal(pushCalls.length, 1);
     assert.equal(pushCalls[0].forceWithLease, true);
     assert.equal(reviews[0].event, "COMMENT");
-    assert.ok(comments.some((body) => /resumed this issue/i.test(body)));
+    assert.ok(
+      comments.some(
+        (body) =>
+          /Agent worker resumed this issue\./.test(body) && /Resume phase: execution/.test(body)
+      )
+    );
     assert.ok(
       comments.some(
         (body) =>
@@ -1398,7 +1403,14 @@ test("runGitHubIssueWorker resumes a failed run from persisted execution state",
     assert.equal(updatedRun.id, priorRun.id);
     assert.equal(updatedRun.commitSha, "resume123");
     assert.equal(updatedRun.lastCompletedPhase, "reconciled");
-    assert.ok(events.some((event) => event.event === "run_resumed"));
+    assert.ok(
+      events.some(
+        (event) =>
+          event.event === "run_resumed" &&
+          event.message === `Resuming run ${priorRun.id} from execution.` &&
+          event.data?.resumePhase === "execution"
+      )
+    );
     assert.ok(events.some((event) => event.event === "execution_resumed"));
     assert.ok(events.some((event) => event.event === "commit_reused"));
     assert.ok(findPrCalls >= 1);
@@ -1778,7 +1790,12 @@ test("runGitHubIssueWorker reruns execution after needs_changes using prior crit
     assert.equal(pushCalls.length, 1);
     assert.equal(pushCalls[0].forceWithLease, true);
     assert.equal(reviews[0].event, "COMMENT");
-    assert.ok(comments.some((body) => /resumed this issue/i.test(body)));
+    assert.ok(
+      comments.some(
+        (body) =>
+          /Agent worker resumed this issue\./.test(body) && /Resume phase: execution/.test(body)
+      )
+    );
     assert.ok(
       comments.some(
         (body) =>
@@ -1796,7 +1813,10 @@ test("runGitHubIssueWorker reruns execution after needs_changes using prior crit
     assert.equal(updatedRun.lastCompletedPhase, "reconciled");
     assert.ok(
       events.some(
-        (event) => event.event === "run_resumed" && event.data?.resumePhase === "execution"
+        (event) =>
+          event.event === "run_resumed" &&
+          event.message === `Resuming run ${priorRun.id} from execution.` &&
+          event.data?.resumePhase === "execution"
       )
     );
     assert.ok(events.some((event) => event.event === "execution_started"));


### PR DESCRIPTION
## Summary
- cache the inferred resume phase once per claim/resume flow in the GitHub issue worker runtime
- reuse the cached phase for the `run_resumed` event, resume issue comment, and worker execution summary
- keep existing resume semantics and user-visible wording unchanged
- strengthen resume-path assertions so event/comment/summary outputs stay aligned

## Testing
- `node --test scripts/tests/issue-driven-os-github-runtime.test.js`
- `npx eslint scripts/lib/issue-driven-os-github-runtime.js scripts/tests/issue-driven-os-github-runtime.test.js`
- `npx prettier --check scripts/lib/issue-driven-os-github-runtime.js scripts/tests/issue-driven-os-github-runtime.test.js`
Closes #25
## Agent Summary
Updated `scripts/lib/issue-driven-os-github-runtime.js` to introduce shared resume-claim metadata built from a single `inferResumePhase(resumeContext)` call, then reused that cached value for the `run_resumed` event message/data, the resume issue comment, and the `resume-from-*` execution-summary verification string. Tightened `scripts/tests/issue-driven-os-github-runtime.test.js` to assert the exact execution resume phase appears consistently in the resume comment, execution summary, and runtime event message/data for both failed-run resume and needs-changes rework resume paths.
## Verification
Passed `node --test scripts/tests/issue-driven-os-github-runtime.test.js` (19 tests, 19 passed). Passed `npx eslint scripts/lib/issue-driven-os-github-runtime.js scripts/tests/issue-driven-os-github-runtime.test.js`. Passed `npx prettier --check scripts/lib/issue-driven-os-github-runtime.js scripts/tests/issue-driven-os-github-runtime.test.js`.

---
Agent type: issue-cell-executor
Phase: review
Run id: run_issue_25_20260330T100211Z
Issue: #25
Workflow: issue-driven-os
Execution Summary: agents=issue-cell-executor; skills=clarify, execution-briefing, handoff-bundle-writing; tools=codex exec, git commit, git push, github pull request; verification=Passed `node --test scripts/tests/issue-driven-os-github-runtime.test.js` (19 tests, 19 passed). Passed `npx eslint scripts/lib/issue-driven-os-github-runtime.js scripts/tests/issue-driven-os-github-runtime.test.js`. Passed `npx prettier --check scripts/lib/issue-driven-os-github-runtime.js scripts/tests/issue-driven-os-github-runtime.test.js`.; limits=none
<!-- issue-driven-os-summary {"agents":"issue-cell-executor","skills":"clarify, execution-briefing, handoff-bundle-writing","tools":"codex exec, git commit, git push, github pull request","verification":"Passed `node --test scripts/tests/issue-driven-os-github-runtime.test.js` (19 tests, 19 passed). Passed `npx eslint scripts/lib/issue-driven-os-github-runtime.js scripts/tests/issue-driven-os-github-runtime.test.js`. Passed `npx prettier --check scripts/lib/issue-driven-os-github-runtime.js scripts/tests/issue-driven-os-github-runtime.test.js`.","limits":"none"} -->
<!-- issue-driven-os-meta {"schemaVersion":1,"workflow":"issue-driven-os","actor":"issue-cell-executor","phase":"review","channel":"pull_request_body","runId":"run_issue_25_20260330T100211Z","issueNumber":25,"pullRequestNumber":null} -->